### PR TITLE
Changed all 'hydraContent' variables to 'content' in test files

### DIFF
--- a/client-side/src/app/hydra-client/services/batch/hydra-batch.service.spec.ts
+++ b/client-side/src/app/hydra-client/services/batch/hydra-batch.service.spec.ts
@@ -10,7 +10,7 @@ import { environment } from '../../../../environments/environment';
 
 fdescribe('HydraBatchService', () => {
   const batch = new HydraBatch();
-  this.context = environment.hydraContext;
+  this.context = environment.context;
   batch.trainer = 100;
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/client-side/src/app/hydra-client/services/trainee/hydra-trainee.service.spec.ts
+++ b/client-side/src/app/hydra-client/services/trainee/hydra-trainee.service.spec.ts
@@ -9,7 +9,7 @@ import { environment } from '../../../../environments/environment';
 
 fdescribe('HydraTraineeService', () => {
   const trainee = new HydraTrainee();
-  this.context = environment.hydraContext;
+  this.context = environment.context;
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [HydraTraineeService, UrlService],

--- a/client-side/src/app/hydra-client/services/trainer/trainer.service.spec.ts
+++ b/client-side/src/app/hydra-client/services/trainer/trainer.service.spec.ts
@@ -10,7 +10,7 @@ import { environment } from '../../../../environments/environment';
 fdescribe('TrainerService', () => {
   const trainer: HydraTrainer = new HydraTrainer();
   trainer.email = 'hey@stop.it';
-  this.context = environment.hydraContext;
+  this.context = environment.context;
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [TrainerService, UrlService],

--- a/client-side/src/environments/environment.ts
+++ b/client-side/src/environments/environment.ts
@@ -7,7 +7,7 @@ const bam = 'http://localhost:9001/api/v2';
 export const environment = {
   production: false,
 
-  hydraContext: 'http://localhost:8765/',
+  //hydraContext: 'http://localhost:9001/api/v2',
 
   context: context, // change for what the production environment would actually be
   bam: bam,


### PR DESCRIPTION
#### Reviewers:
@josephjustn @jenfox @khsieh
#### Observers:
@jmknighten9 
#### Repository
janus-webapp
#### Related Pull Requests:
none
#### Description:
Changed all instances of 'hydraContent' within the test files to 'content'. 'hydraContent' was directing tests to port 8765, instead of 9001/api/v2.
#### Effect on Project or other Services:
Now have successful tests running.